### PR TITLE
refactor: update get response type

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1237,7 +1237,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-pubky (0.10.2):
+  - react-native-pubky (0.10.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1757,7 +1757,7 @@ SPEC CHECKSUMS:
   React-logger: 4072f39df335ca443932e0ccece41fbeb5ca8404
   React-Mapbuffer: 714f2fae68edcabfc332b754e9fbaa8cfc68fdd4
   React-microtasksnativemodule: 4943ad8f99be8ccf5a63329fa7d269816609df9e
-  react-native-pubky: b75611d5a4e02c66967555b7be2f837fc3628b8e
+  react-native-pubky: c17a151ec1ce63258083c97a2a97500fd043170c
   React-nativeconfig: 4a9543185905fe41014c06776bf126083795aed9
   React-NativeModulesApple: 0506da59fc40d2e1e6e12a233db5e81c46face27
   React-perflogger: 3bbb82f18e9ac29a1a6931568e99d6305ef4403b

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synonymdev/react-native-pubky",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "React Native Implementation of Pubky",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -199,7 +199,7 @@ export async function signOut(secretKey: string): Promise<Result<string[]>> {
   }
 }
 
-export async function get(url: string): Promise<Result<string[]>> {
+export async function get(url: string): Promise<Result<unknown>> {
   try {
     const res = await Pubky.get(url);
     if (res[0] === 'error') {


### PR DESCRIPTION
This PR:
- Updates `get` response type to `unknown`.
- Bumps version to `0.10.3`.