### PR TITLE
chore: bump jna from 5.16.0 to 5.18.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,7 +98,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   // Uniffi
-  implementation("net.java.dev.jna:jna:5.16.0@aar")
+  implementation("net.java.dev.jna:jna:5.18.1@aar")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1782,7 +1782,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-pubky (0.11.2):
+  - react-native-pubky (0.11.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2626,7 +2626,7 @@ SPEC CHECKSUMS:
   React-logger: fceaaedb9c715923a1900af68a7534e9b3a601a1
   React-Mapbuffer: 7e7ca4c53288117e7e0406e9eaa804bf259b4b30
   React-microtasksnativemodule: 885bebe5c5f25035e1fd0920776078840a0e3a76
-  react-native-pubky: f866b2fb19f743d6bd89638498789062512169ec
+  react-native-pubky: 7492bb86af00f79ee9dee25b5fd7ac9e1c5748a8
   React-NativeModulesApple: c4bee6aa736092cd347456488a4f97a8e7517604
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: d5b5677902d23a6611b700601634271b29356ac6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synonymdev/react-native-pubky",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "React Native Implementation of Pubky",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
This PR:
- Bumps jna from `5.16.0` to `5.18.1`
- Bumps version to `0.11.3`